### PR TITLE
Join Missions

### DIFF
--- a/src/components/SingleMission.js
+++ b/src/components/SingleMission.js
@@ -1,18 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission } from '../redux/missions/missions';
 
-const SingleMission = ({ name, description }) => (
-  <>
-    <td className="name">{ name }</td>
-    <td>{ description }</td>
-    <td><span className="member">Not A Member</span></td>
-    <td><button type="button" className="join">Join Mission</button></td>
-  </>
-);
+const SingleMission = ({ name, description, id }) => {
+  const dispatch = useDispatch();
+
+  return (
+    <>
+      <td className="name">{name}</td>
+      <td>{description}</td>
+      <td><span className="member">Not A Member</span></td>
+      <td>
+        <button
+          type="button"
+          className="join"
+          onClick={() => dispatch(joinMission(id))}
+        >
+          Join Mission
+        </button>
+      </td>
+    </>
+  );
+};
 
 SingleMission.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
 };
 
 export default SingleMission;

--- a/src/pages/Missions.js
+++ b/src/pages/Missions.js
@@ -23,7 +23,7 @@ const Missions = () => {
               const { name, id, description } = mission;
               return (
                 <tr key={id} className="mission-row">
-                  <SingleMission name={name} description={description} />
+                  <SingleMission name={name} description={description} id={id} />
                 </tr>
               );
             })}

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,7 +1,13 @@
 const FETCH_MISSIONS = 'react-spacex/missions/FETCH_MISSIONS';
+const JOIN_MISSIONS = 'react-spacex/missions/JOIN_MISSIONS';
 
 export const fetchMissions = (missions) => ({
   type: FETCH_MISSIONS,
+  missions,
+});
+
+export const joinMission = (missions) => ({
+  type: JOIN_MISSIONS,
   missions,
 });
 
@@ -33,6 +39,17 @@ const missionsReducer = (state = initialState, action) => {
       return {
         ...state,
         newMissions: action.missions,
+      };
+
+    case JOIN_MISSIONS:
+      return {
+        ...state,
+        newMissions: state.newMissions.map((mission) => {
+          if (mission.mission_id !== action.id) {
+            return { ...mission };
+          }
+          return { ...mission, reserved: true };
+        }),
       };
     default:
       return state;


### PR DESCRIPTION
## In this PR, the following task was worked on
- Create a reducer and action dispatcher for the "Join Mission" button. The logic here is practically the same as with rockets - you need to pass the mission's ID to the corresponding action and update the missions' state with the selected mission having a new key/value - `reserved: true`.

Closes #10 