### PR TITLE
Switch Missions Badge

### DIFF
--- a/src/components/SingleMission.js
+++ b/src/components/SingleMission.js
@@ -3,29 +3,47 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { joinMission, leaveMission } from '../redux/missions/missions';
 
-const SingleMission = ({ name, description, id }) => {
+const SingleMission = ({
+  name,
+  description,
+  id,
+  reserved,
+}) => {
   const dispatch = useDispatch();
 
   return (
     <>
       <td className="name">{name}</td>
       <td>{description}</td>
-      <td><span className="member">Not A Member</span></td>
       <td>
-        <button
-          type="button"
-          className="btn join"
-          onClick={() => dispatch(joinMission(id))}
-        >
-          Join Mission
-        </button>
-        <button
-          type="button"
-          className="btn leave"
-          onClick={() => dispatch(leaveMission(id))}
-        >
-          Leave Mission
-        </button>
+        {
+        reserved
+          ? <span className="member active">Active Member</span>
+          : <span className="member not-active">Not A Member</span>
+        }
+      </td>
+      <td>
+        {
+        !reserved
+          ? (
+            <button
+              type="button"
+              className="btn join"
+              onClick={() => dispatch(joinMission(id))}
+            >
+              Join Mission
+            </button>
+          )
+          : (
+            <button
+              type="button"
+              className="btn leave"
+              onClick={() => dispatch(leaveMission(id))}
+            >
+              Leave Mission
+            </button>
+          )
+        }
       </td>
     </>
   );
@@ -35,6 +53,11 @@ SingleMission.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  reserved: PropTypes.bool,
+};
+
+SingleMission.defaultProps = {
+  reserved: false,
 };
 
 export default SingleMission;

--- a/src/pages/Missions.css
+++ b/src/pages/Missions.css
@@ -38,10 +38,17 @@ td:nth-child(4) {
 .member {
   text-transform: uppercase;
   color: #fff;
-  background-color: gray;
   padding: 4px 6px;
   font-size: 13px;
   border-radius: 5px;
+}
+
+.not-active {
+  background-color: gray;
+}
+
+.active {
+  background-color: rgb(86, 177, 86);
 }
 
 .btn {

--- a/src/pages/Missions.js
+++ b/src/pages/Missions.js
@@ -20,10 +20,21 @@ const Missions = () => {
 
           <tbody>
             {missions && missions.map((mission) => {
-              const { name, id, description } = mission;
+              const {
+                name,
+                id,
+                description,
+                reserved,
+              } = mission;
+
               return (
                 <tr key={id} className="mission-row">
-                  <SingleMission name={name} description={description} id={id} />
+                  <SingleMission
+                    name={name}
+                    description={description}
+                    id={id}
+                    reserved={reserved}
+                  />
                 </tr>
               );
             })}

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -50,23 +50,21 @@ const missionsReducer = (state = initialState, action) => {
     case JOIN_MISSIONS:
       return {
         ...state,
-        newMissions: state.newMissions.map((mission) => {
-          if (mission.mission_id !== action.id) {
-            return { ...mission };
-          }
-          return { ...mission, reserved: true };
-        }),
+        newMissions: state.newMissions.map((mission) => (
+          (mission.id !== action.missions)
+            ? { ...mission }
+            : { ...mission, reserved: true }
+        )),
       };
 
     case LEAVE_MISSIONS:
       return {
         ...state,
-        newMissions: state.newMissions.map((mission) => {
-          if (mission.mission_id !== action.id) {
-            return { ...mission };
-          }
-          return { ...mission, reserved: false };
-        }),
+        newMissions: state.newMissions.map((mission) => (
+          (mission.id !== action.missions)
+            ? { ...mission }
+            : { ...mission, reserved: false }
+        )),
       };
     default:
       return state;


### PR DESCRIPTION
### In this PR, I completed the following task;

- [x] Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).

Closes #6